### PR TITLE
Field access kmc 885

### DIFF
--- a/discourse.permissions.yml
+++ b/discourse.permissions.yml
@@ -1,0 +1,4 @@
+manage discourse connections:
+  title: 'Manage Discourse connections'
+  description: 'See and edit fields related to Discourse "mappings" on Users. (Will apply to Groups and Discussions in the future).'
+  restrict access: TRUE

--- a/modules/discourse_membership/src/Plugin/Field/FieldWidget/DiscourseUserWidget.php
+++ b/modules/discourse_membership/src/Plugin/Field/FieldWidget/DiscourseUserWidget.php
@@ -32,12 +32,24 @@ class DiscourseUserWidget extends WidgetBase {
       '#default_value' => isset($items[$delta]->push_to_discourse) ? $items[$delta]->push_to_discourse : TRUE,
     ];
 
+    $element['allow_override'] = [
+      '#title' => $this->t('Allow manual override of discourse connection fields.'),
+      '#description' => $this->t('WARNING: use with care. It is generally advised not to use this option, unless something has gone wrong with this user/discourse connection.'),
+      '#type' => 'checkbox',
+      '#default_value' => FALSE,
+    ];
+
+    $allowed_selector = "discourse_user_field[" . $delta . "][allow_override]";
     $element['user_id'] = [
       '#type' => 'number',
       '#title' => $this->t('Discourse User ID'),
       '#default_value' => isset($items[$delta]->user_id) ? $items[$delta]->user_id : NULL,
       '#size' => 5,
-      '#disabled' => TRUE,
+      '#states' => [
+        'enabled' => [
+          ':input[name="' . $allowed_selector . '"]' => ['checked' => TRUE],
+        ],
+      ],
     ];
 
     $element['username'] = [
@@ -47,7 +59,11 @@ class DiscourseUserWidget extends WidgetBase {
       '#size' => 60,
       '#placeholder' => '',
       '#maxlength' => 256,
-      '#disabled' => TRUE,
+      '#states' => [
+        'enabled' => [
+          ':input[name="' . $allowed_selector . '"]' => ['checked' => TRUE],
+        ],
+      ],
     ];
 
     $element += [

--- a/modules/discourse_membership/src/Plugin/Field/FieldWidget/DiscourseUserWidget.php
+++ b/modules/discourse_membership/src/Plugin/Field/FieldWidget/DiscourseUserWidget.php
@@ -54,6 +54,7 @@ class DiscourseUserWidget extends WidgetBase {
       '#type' => 'details',
       '#group' => 'advanced',
       '#weight' => 0,
+      '#access' => \Drupal::currentUser()->hasPermission('manage discourse connections'),
     ];
 
     return $element;


### PR DESCRIPTION
This is to address https://github.com/united-philanthropy-forum/km-collaborative/issues/885

It does 3 things:
1. Adds a permission for managing entity discourse connections
2. Uses that permission to selectively block access to the discourse user field-group
3. Adds a toggle to allow users who can see the fields to actually modify them. This is outside the scope of this ticket, but I experimented with it while I was in there and it worked exactly as desired so I included it, since it was simple.