### PR TITLE
Adds the 'push_to_discourse' flag to users on membership sync.

### DIFF
--- a/modules/discourse_membership/discourse_membership.module
+++ b/modules/discourse_membership/discourse_membership.module
@@ -189,6 +189,7 @@ function discourse_membership_sync_membership(GroupContentInterface $group_conte
       // Save the discourse user values back to the Drupal user.
       $user->discourse_user_field->username = $user->getAccountName();
       $user->discourse_user_field->user_id = $created_user['user_id'];
+      $user->discourse_user_field->push_to_discourse = 1;
       $user->save();
     }
   }


### PR DESCRIPTION
## UNTESTED

See https://github.com/United-Philanthropy-Forum/km-collaborative/issues/1025 for background. 

This addresses an issue where, after joining or being assigned a group, a Drupal user's account gets pushed to Discourse, but isn't flagged to be synced. On subsequent sync actions, the module tries to create a new account because of the missing flag, which fails because the user already exists.

