### PR TITLE
Addresses discourse username becoming out of sync when Drupal username changes

### DIFF
--- a/fix-discourse-usernames.php
+++ b/fix-discourse-usernames.php
@@ -1,0 +1,81 @@
+<?php
+
+/*
+ * Drush script to reconcile Drupal-side Discourse username field with data from
+ * the upstream Discourse app.
+ *
+ * While paging through the discourse user listing, update corresponding
+ * discourse usernames based on matching discourse user id.
+ *
+ * Mismatches between Drupal username and Discourse name are logged for
+ * informational purposes only, but not updated.
+ */
+
+/** @var \Drupal\discourse\DiscourseApiClient $discourse_client */
+$discourse_client = \Drupal::service('discourse.discourse_api_client');
+$page = 1;
+while ($discourse_data = $discourse_client->getUsers($page)) {
+  $discourse_cleaned = [];
+  if (!$discourse_data) {
+    break;
+  }
+  $discourse_data = json_decode($discourse_data);
+  if (empty($discourse_data)) {
+    break;
+  }
+  foreach ($discourse_data as $user) {
+    $discourse_cleaned[$user->id] = $user;
+  }
+  $page++;
+
+  $query = \Drupal::entityTypeManager()->getStorage('user')->getQuery();
+  $query->condition('discourse_user_field__user_id', array_keys($discourse_cleaned), 'IN');
+  $query->exists('discourse_user_field__push_to_discourse');
+  $query->exists('discourse_user_field__username');
+  $results = $query->execute();
+
+  foreach ($results as $uid) {
+    $account = \Drupal\user\Entity\User::load($uid);
+    if (empty($account)) {
+      \Drupal::logger('discourse')
+        ->notice('Skip empty account :uid', [':uid' => $uid]);
+      continue;
+    }
+    $discourse_id = $account->discourse_user_field->user_id;
+    if (empty($discourse_cleaned[$discourse_id])) {
+      \Drupal::logger('discourse')
+        ->notice('No discourse match found for user :uid username from discourse :username', [
+          ':uid' => $account->id(),
+          ':username' => $account->getAccountName()
+        ]);
+      continue;
+    }
+
+    if ($account->getAccountName() != $discourse_cleaned[$discourse_id]->username) {
+      \Drupal::logger('discourse')
+        ->warning('Discourse username does not match drupal not match :uid :username :disco', [
+          ':uid' => $account->id(),
+          ':username' => $account->getAccountName(),
+          ':disco' => $discourse_cleaned[$discourse_id]->username
+        ]);
+      continue;
+    }
+
+    if ($account->discourse_user_field->username == $discourse_cleaned[$discourse_id]->username) {
+      \Drupal::logger('discourse')
+        ->notice('Discourse name already match for user :uid username from discourse :username', [
+          ':uid' => $account->id(),
+          ':username' => $account->getAccountName()
+        ]);
+      continue;
+    }
+    $account->discourse_user_field->username = $discourse_cleaned[$discourse_id]->username;
+    $account->save();
+    \Drupal::logger('discourse')
+      ->notice('Updated user :uid disco username from discourse :username', [
+        ':uid' => $account->id(),
+        ':username' => $account->getAccountName()
+      ]);
+
+  }
+}

--- a/modules/discourse_membership/discourse_membership.module
+++ b/modules/discourse_membership/discourse_membership.module
@@ -10,6 +10,7 @@ use Drupal\Core\Field\BaseFieldDefinition;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Entity\EntityInterface;
+use Drupal\user\Entity\User;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\group\Entity\GroupContentInterface;
 
@@ -192,4 +193,25 @@ function discourse_membership_sync_membership(GroupContentInterface $group_conte
       $user->save();
     }
   }
+}
+
+/**
+ * Implements hook_discourse_sso_parameters_alter().
+ */
+function discourse_membership_discourse_sso_parameters_alter(&$parameters) {
+  // If a user is SSO'ing and including a "username" parameter, this acts as an
+  // instruction to Discourse to update the Discourse username. That means we
+  // need to update our username on file.
+  if (empty($parameters['external_id']) || !is_numeric($parameters['external_id'])) {
+    return;
+  }
+  $account = User::load($parameters['external_id']);
+  if (empty($account) || empty($account->get('discourse_user_field'))) {
+    return;
+  }
+  if (empty($account->discourse_user_field->username) || $account->discourse_user_field->username == $parameters['username']) {
+    return;
+  }
+  $account->discourse_user_field->username = $parameters['username'];
+  $account->save();
 }

--- a/src/DiscourseApiClient.php
+++ b/src/DiscourseApiClient.php
@@ -473,6 +473,20 @@ class DiscourseApiClient {
   }
 
   /**
+   * Get the list of users from Discourse.
+   *
+   * @param int $page
+   *   For multiple pages of results, call repeatedly and increment value.
+   *
+   * @return bool|string
+   *   JSON response or FALSE.
+   */
+  public function getUsers($page = 1) {
+    $uri = '/admin/users/list/new.json?page=' . $page;
+    return $this->getRequest($uri);
+  }
+
+  /**
    * Creates a category.
    *
    * @param array $data


### PR DESCRIPTION
Background on this issue in https://github.com/United-Philanthropy-Forum/km-collaborative/issues/1110

Includes:

* New API endpoint getUsers to fetch a list of users from Discourse
* hook_discourse_sso_parameters_alter implementation to keep Discourse username in sync on the Drupal side when a user logs in via SSO
* A drush script to clean up existing out-of-sync records.