### PR TITLE
Fix user creation

### DIFF
--- a/modules/discourse_membership/discourse_membership.module
+++ b/modules/discourse_membership/discourse_membership.module
@@ -11,6 +11,7 @@ use Drupal\Core\Form\FormStateInterface;
 use Drupal\Component\Serialization\Json;
 use Drupal\Core\Entity\EntityInterface;
 use Drupal\user\Entity\User;
+use Drupal\user\UserInterface;
 use Drupal\Core\Routing\RouteMatchInterface;
 use Drupal\group\Entity\GroupContentInterface;
 
@@ -56,33 +57,24 @@ function discourse_membership_form_user_form_alter(&$form, FormStateInterface $f
 }
 
 /**
- * Post group to discourse.
+ * Post user to discourse.
  */
 function _post_user_to_discourse($form, FormStateInterface &$form_state) {
   $form_values = $form_state->getValues();
   $user = $form_state->getFormObject()->getEntity();
   $discourse_user_id = $user->get('discourse_user_field')->user_id;
   $post_condition = $discourse_user_id == NULL && $discourse_user_id !== '' && $form_values['discourse_user_field'][0]['push_to_discourse'] == 1;
-  // New group.
+  // New user.
   if ($post_condition) {
-    // Create the discourse group.
-    $data = [
-      'name' => $form_values['name'],
-      'email' => $form_values['mail'],
-      'password' => \Drupal::service('password_generator')->generate(10),
-      'username' => substr(preg_replace("/[^A-Za-z0-9_\-\.]/", '', $form_values['name']), 0, 20),
-      'active' => TRUE,
-      'approved' => TRUE,
-      'user_fields[1]' => TRUE,
-    ];
-    $created_user = discourse_membership_fetch_or_create_user($data);
+    // Create the discourse user.
+    $created_user = discourse_membership_fetch_or_create_user($user);
 
     // Get user details and save it in discourse field of the user.
     $discourse_form_values = $form_values['discourse_user_field'];
-    $discourse_form_values[0]['user_id'] = $created_user['user_id'];
-    $discourse_form_values[0]['username'] = !empty($created_user['username'])
-      ? $created_user['username']
-      : $data['username'];
+    $discourse_form_values[0]['user_id'] = $created_user['id'];
+    if (!empty($created_user['username'])) {
+      $discourse_form_values[0]['username'] = $created_user['username'];
+    }
 
     // Change the discourse_groups_field according to returned values.
     $user->set('discourse_user_field', $discourse_form_values);
@@ -174,43 +166,81 @@ function discourse_membership_sync_membership(GroupContentInterface $group_conte
   }
   else {
     // Create the discourse user.
-    $data = [
-      'name' => $user->getAccountName(),
-      'email' => $user->getEmail(),
-      'password' => \Drupal::service('password_generator')->generate(10),
-      'username' => substr(preg_replace("/[^A-Za-z0-9_\-\.]/", '', $user->getAccountName()), 0, 20),
-      'active' => TRUE,
-      'approved' => TRUE,
-      'user_fields[1]' => TRUE,
-    ];
-    $created_user = discourse_membership_fetch_or_create_user($data);
-    if (isset($created_user['user_id']) && !empty($created_user['user_id'])) {
-      $discourse_api_client->addUsersToGroup($group_id, $user->getAccountName());
+    $created_user = discourse_membership_fetch_or_create_user($user);
+    if ($created_user && !empty($created_user['id'])) {
+      $username = $created_user['username'] ?? $user->getAccountName();
+      $group_add_result = $discourse_api_client->addUsersToGroup($group_id, $username);
       // Save the discourse user values back to the Drupal user.
-      $user->discourse_user_field->username = $data['username'];
-      $user->discourse_user_field->user_id = $created_user['user_id'];
+      $user->discourse_user_field->username = $username;
+      $user->discourse_user_field->user_id = $created_user['id'];
       $user->discourse_user_field->push_to_discourse = 1;
       $user->save();
     }
   }
 }
 
-function discourse_membership_fetch_or_create_user(array $data) {
+/**
+ * Take a Drupal user and return a matching, potentially new Discourse user.
+ *
+ * @param \Drupal\user\UserInterface $account
+ *   The Drupal user that will be used to look up or create the Discourse user.
+ *
+ * @return array|null
+ */
+function discourse_membership_fetch_or_create_user(UserInterface $account) {
   /** @var \Drupal\discourse\DiscourseApiClient $discourse_api_client */
   $discourse_api_client = \Drupal::service('discourse.discourse_api_client');
+  $data = [
+    'name' => $account->getAccountName(),
+    'email' => $account->getEmail(),
+    'password' => \Drupal::service('password_generator')->generate(10),
+    'username' => substr(preg_replace("/[^A-Za-z0-9_\-\.]/", '', $account->getAccountName()), 0, 20),
+    'active' => TRUE,
+    'approved' => TRUE,
+    'user_fields[1]' => TRUE,
+  ];
   // Search discourse for the user, given the email.
-  $get_user = Json::decode($discourse_api_client->getUsers(1, [
-    'show_emails' => TRUE,
-    'filter' => $data['email'],
-  ]));
-  // If user exists, return existing.
-  if (!empty($get_user['users'])) {
-    return current($get_user['users']);
+  $existing_user = discourse_get_discourse_user_from_email($data['email']);
+  if ($existing_user) {
+    return $existing_user;
   }
   else {
-    // If not user exists, create and return new account.
-    return Json::decode($discourse_api_client->createUser($data));
+    $new_user_result = Json::decode($discourse_api_client->createUser($data));
+    if ($new_user_result['success']) {
+      $new_user = discourse_get_discourse_user_from_email($data['email']);
+      if ($new_user) {
+        return $new_user;
+      }
+      elseif (isset($new_user_result['user_id'])) {
+        // Sometimes the Discourse server won't load new users in queries, but
+        // if we have a user ID we can at least provide a thin version:
+        return ['id' => $new_user_result['user_id']];
+      }
+    }
   }
+  return NULL;
+}
+
+/**
+ * Get a discourse use from an email address.
+ *
+ * @param String $email
+ *   The email address with which to look up the user in Discourse.
+ *
+ * @return array|null
+ */
+function discourse_get_discourse_user_from_email(String $email) {
+  /** @var \Drupal\discourse\DiscourseApiClient $discourse_api_client */
+  $discourse_api_client = \Drupal::service('discourse.discourse_api_client');
+  $get_users = Json::decode($discourse_api_client->getUsers(1, [
+    'show_emails' => TRUE,
+    'filter' => $email,
+  ]));
+  // If user exists, return existing.
+  if (!empty($get_users)) {
+    return current($get_users);
+  }
+  return NULL;
 }
 
 /**


### PR DESCRIPTION
https://github.com/United-Philanthropy-Forum/km-collaborative/issues/1588

- don't use form inputs when creating Discourse users on Drupal user registration, as it gets the wrong username due to email registration module
- always check for a user before inserting